### PR TITLE
Always log error to error log

### DIFF
--- a/domain/health/health_middleware/health_middleware.go
+++ b/domain/health/health_middleware/health_middleware.go
@@ -58,7 +58,6 @@ func (hm *HealthMiddleware) CheckForErrors() gin.HandlerFunc {
 //middleware activity
 func (hm *HealthMiddleware) errorMiddleware(c *gin.Context) {
 	//setup writer
-	fmt.Println("try middleware")
 	blw := &bodyLogWriter{body: bytes.NewBufferString(""), ResponseWriter: c.Writer}
 	c.Writer = blw
 

--- a/domain/logs/log_service/log_service.go
+++ b/domain/logs/log_service/log_service.go
@@ -52,13 +52,13 @@ func (ls *LogService) RecentError(record *log_model.ErrorLog) (bool, error) {
 
 	interval := lastError.Time.Add(time.Minute * time.Duration(context.Config.DbVars.ErrorReportDelay))
 
+	err = ls.RepositoriesGroup.LogRepository.RecordError(record)
+	if err != nil {
+		return true, err
+	}
+
 	if time.Now().After(interval) {
 		//record the error its new and recent
-		err := ls.RepositoriesGroup.LogRepository.RecordError(record)
-		if err != nil {
-			return true, err
-		}
-
 		return true, nil
 	}
 	return false, nil

--- a/init/database/sql/migrations/sql/7_error_report_database_controls.go
+++ b/init/database/sql/migrations/sql/7_error_report_database_controls.go
@@ -7,7 +7,7 @@ func ErrorReportingMigration() *migrate.Migration {
 		Id: "7",
 		Up: []string{`
 			INSERT INTO gocms_settings (name, value, description) VALUES ('ERROR_REPORT_ADDRESS', 'default@gocms.io', 'Specify address to send error reports');`, `
-			INSERT INTO gocms_settings (name, value, description) VALUES ('ERROR_EMAIL_DELAY', '60', 'Specify the minimum frequency error emails will be sent and recorded. Minutes');`,`
+			INSERT INTO gocms_settings (name, value, description) VALUES ('ERROR_EMAIL_DELAY', '10', 'Specify the minimum frequency error emails will be sent and recorded. Minutes');`,`
 			CREATE TABLE gocms_error_logs (route varchar(255), status varchar(255), body varchar(255), date datetime);
 			`,
 		},


### PR DESCRIPTION
Always log error to error log.  Change default 'time between email error report' to 10 minutes. 